### PR TITLE
Make requirementId optional

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -185,7 +185,11 @@ describe('src/index', () => {
       })
     })
 
-    describe('should set both requirementId and requestData values at the same time', () => {
+    describe('when it receives only the argument of requirementId', () => {
+      const Tester = () => {
+        useXhr(undefined, {httpMethod: 'GET', url: ''})
+        return React.createElement('div')
+      }
       let originalConsoleError: any;
 
       beforeEach(() => {
@@ -197,11 +201,7 @@ describe('src/index', () => {
         console.error = originalConsoleError
       })
 
-      it('should throw an error if only requirementId is undefined', async () => {
-        const Tester = () => {
-          useXhr({httpMethod: 'GET', url: ''}, undefined)
-          return React.createElement('div')
-        }
+      it('should throw an error', async () => {
         let error: any = undefined
         try {
           await ReactTestRenderer.act(async () => {
@@ -211,24 +211,7 @@ describe('src/index', () => {
           error = err
         }
         expect(error).toBeInstanceOf(Error)
-        expect(error.message).toContain(' are not set ')
-      })
-
-      it('should throw an error if only requestData is undefined', async () => {
-        const Tester = () => {
-          useXhr(undefined, 'a')
-          return React.createElement('div')
-        }
-        let error: any = undefined
-        try {
-          await ReactTestRenderer.act(async () => {
-            ReactTestRenderer.create(React.createElement(Tester))
-          })
-        } catch (err) {
-          error = err
-        }
-        expect(error).toBeInstanceOf(Error)
-        expect(error.message).toContain(' are not set ')
+        expect(error.message).toContain(' specify only ')
       })
     })
 

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -135,7 +135,7 @@ describe('src/index', () => {
 
       it('should throw an error if only requirementId is undefined', async () => {
         const Tester = () => {
-          useXhr(undefined, {httpMethod: 'GET', url: ''})
+          useXhr({httpMethod: 'GET', url: ''}, undefined)
           return React.createElement('div')
         }
         let error: any = undefined
@@ -152,7 +152,7 @@ describe('src/index', () => {
 
       it('should throw an error if only requestData is undefined', async () => {
         const Tester = () => {
-          useXhr('a', undefined)
+          useXhr(undefined, 'a')
           return React.createElement('div')
         }
         let error: any = undefined
@@ -183,11 +183,11 @@ describe('src/index', () => {
 
       it('should throw an error if requestData is changed in the same requirementId', async () => {
         const Tester: React.FC<{body: string}> = (props) => {
-          useXhr('a', {
+          useXhr({
             httpMethod: 'GET',
             url: '/foo',
             body: props.body,
-          })
+          }, 'a')
           return React.createElement('div')
         }
 
@@ -255,10 +255,10 @@ describe('src/index', () => {
         handleResult: (result: UseXhrResult) => void,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr('a', {
+        const result = useXhr({
           httpMethod: 'GET',
           url: '/foo',
-        })
+        }, 'a')
         props.handleResult(result)
         return React.createElement('div')
       }
@@ -298,7 +298,7 @@ describe('src/index', () => {
         requirementId: string | undefined,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr(props.requirementId, props.requestData)
+        const result = useXhr(props.requestData, props.requirementId)
         props.handleResult(result)
         return React.createElement('div')
       }
@@ -348,7 +348,7 @@ describe('src/index', () => {
         requirementId: string,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr(props.requirementId, props.requestData)
+        const result = useXhr(props.requestData, props.requirementId)
         props.handleResult(props.requirementId, result)
         return React.createElement('div')
       }
@@ -427,7 +427,7 @@ describe('src/index', () => {
         requirementId: string | undefined,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr(props.requirementId, props.requestData)
+        const result = useXhr(props.requestData, props.requirementId)
         props.handleResult(result)
         return React.createElement('div')
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,8 @@ const defaultUseXhrState: UseXhrState = {
 }
 
 export function useXhr(
-  requirementId: UseXhrRequirementId | undefined,
   requestData: SendHttpRequestData | undefined,
+  requirementId: UseXhrRequirementId | undefined,
 ): UseXhrResult {
   const [state, setState] = React.useState<UseXhrState>(defaultUseXhrState)
   const unmountedRef = React.useRef(false)

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,8 +97,7 @@ export function useXhr(
   const [state, setState] = React.useState<UseXhrState>(defaultUseXhrState)
   const unmountedRef = React.useRef(false)
   const invalidRequestData =
-    requirementId === undefined && requestData !== undefined ||
-    requirementId !== undefined && requestData === undefined
+    requestData === undefined && requirementId !== undefined
   const requestDataChangedIllegally =
     requirementId !== undefined &&
     areEqualAAndB(requirementId, state.unresolvedRequirementId) &&
@@ -114,7 +113,7 @@ export function useXhr(
     foundResultCache === undefined
 
   if (invalidRequestData) {
-    throw new Error('Both `requirementId` and `requestData` are not set at the same render.')
+    throw new Error('Can not specify only `requirementId`.')
   } else if (requestDataChangedIllegally) {
     throw new Error('Can not change the `requestData` associated with the `requirementId`.')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export function sendHttpRequest(
   xhr.send(data.body !== undefined ? data.body : null)
 }
 
-export type UseXhrRequirementId = number | string
+export type UseXhrRequirementId = number | string | SendHttpRequestData
 
 export type UseXhrResultCache = {
   requirementId: UseXhrRequirementId,
@@ -51,7 +51,7 @@ function findResultCache(
 ): UseXhrResultCache | undefined {
   for (let i = 0; i < resultCaches.length; i++) {
     const resultCache = resultCaches[i]
-    if (resultCache.requirementId === requirementId) {
+    if (areEqualAAndB(resultCache.requirementId, requirementId)) {
       return resultCache
     }
   }
@@ -101,7 +101,7 @@ export function useXhr(
     requirementId !== undefined && requestData === undefined
   const requestDataChangedIllegally =
     requirementId !== undefined &&
-    requirementId === state.unresolvedRequirementId &&
+    areEqualAAndB(requirementId, state.unresolvedRequirementId) &&
     !areEqualAAndB(requestData, state.unresolvedRequestData)
   const foundResultCache = requirementId !== undefined
     ? findResultCache(state.resultCaches, requirementId)
@@ -109,8 +109,8 @@ export function useXhr(
   const startNewRequest =
     requirementId !== undefined &&
     requestData !== undefined &&
-    requirementId !== state.unresolvedRequirementId &&
-    requirementId !== state.resolvedRequirementId &&
+    !areEqualAAndB(requirementId, state.unresolvedRequirementId) &&
+    !areEqualAAndB(requirementId, state.resolvedRequirementId) &&
     foundResultCache === undefined
 
   if (invalidRequestData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,24 +92,26 @@ const defaultUseXhrState: UseXhrState = {
 
 export function useXhr(
   requestData: SendHttpRequestData | undefined,
-  requirementId: UseXhrRequirementId | undefined,
+  requirementId: UseXhrRequirementId | undefined = undefined,
 ): UseXhrResult {
   const [state, setState] = React.useState<UseXhrState>(defaultUseXhrState)
   const unmountedRef = React.useRef(false)
+  const fixedRequirementId: UseXhrRequirementId | undefined =
+    requirementId !== undefined ? requirementId : requestData
   const invalidRequestData =
     requestData === undefined && requirementId !== undefined
   const requestDataChangedIllegally =
-    requirementId !== undefined &&
-    areEqualAAndB(requirementId, state.unresolvedRequirementId) &&
+    fixedRequirementId !== undefined &&
+    areEqualAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
     !areEqualAAndB(requestData, state.unresolvedRequestData)
-  const foundResultCache = requirementId !== undefined
-    ? findResultCache(state.resultCaches, requirementId)
+  const foundResultCache = fixedRequirementId !== undefined
+    ? findResultCache(state.resultCaches, fixedRequirementId)
     : undefined
   const startNewRequest =
-    requirementId !== undefined &&
     requestData !== undefined &&
-    !areEqualAAndB(requirementId, state.unresolvedRequirementId) &&
-    !areEqualAAndB(requirementId, state.resolvedRequirementId) &&
+    fixedRequirementId !== undefined &&
+    !areEqualAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
+    !areEqualAAndB(fixedRequirementId, state.resolvedRequirementId) &&
     foundResultCache === undefined
 
   if (invalidRequestData) {
@@ -122,7 +124,7 @@ export function useXhr(
     // State Transition: 1
     setState({
       reservedNewRequest: true,
-      unresolvedRequirementId: requirementId,
+      unresolvedRequirementId: fixedRequirementId,
       unresolvedRequestData: requestData,
       resultCaches: state.resultCaches,
     })
@@ -181,7 +183,7 @@ export function useXhr(
   const result: UseXhrResult = {
     isLoading: startNewRequest || state.unresolvedRequirementId !== undefined,
   }
-  if (requirementId !== undefined) {
+  if (fixedRequirementId !== undefined) {
     if (state.resolvedRequirementId !== undefined && state.response) {
       result.xhr = state.response.xhr
     } else if (foundResultCache !== undefined) {


### PR DESCRIPTION
- [x] requirementId を省略可能にする。
  - [x] 引数を交換する。
  - [x] requirementId に requestData 相当の値も渡せるようにする。
    - [x] id の比較は等値判定と定める。
  - [x] 引数の省略を許容する。
    - [x] 省略したときは、requestData が渡されたものとみなす。