### PR TITLE
Make maxResultCache configuable

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -136,6 +136,36 @@ describe('src/index', () => {
   })
 
   describe('useXhr', () => {
+    describe('options.maxResultCache', () => {
+      let originalConsoleError: any;
+
+      beforeEach(() => {
+        originalConsoleError = console.error
+        // Hide React's Error Boundary output.
+        console.error = () => {}
+      })
+      afterEach(() => {
+        console.error = originalConsoleError
+      })
+
+      it('should throw an error if the value is less than 1', async () => {
+        const Tester: React.FC = () => {
+          useXhr(undefined, undefined, {maxResultCache: 0})
+          return React.createElement('div')
+        }
+        let error: any = undefined
+        try {
+          await ReactTestRenderer.act(async () => {
+            ReactTestRenderer.create(React.createElement(Tester))
+          })
+        } catch (err) {
+          error = err
+        }
+        expect(error).toBeInstanceOf(Error)
+        expect(error.message).toContain('`maxResultCache`')
+      })
+    })
+
     describe('when it passes the same value with different references to requirementId', () => {
       const requestDataAndRequirementId1: SendHttpRequestData = {
         httpMethod: 'GET',

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -561,7 +561,7 @@ describe('src/index', () => {
         )
       })
 
-      describe('when to enable the cache', () => {
+      describe('when it can save two responses', () => {
         let handleResult: any;
 
         beforeEach(async () => {
@@ -574,11 +574,11 @@ describe('src/index', () => {
         })
       })
 
-      describe('when to disable the cache', () => {
+      describe('when it can not save two responses', () => {
         let handleResult: any;
 
         beforeEach(async () => {
-          const result = await startRender(0)
+          const result = await startRender(1)
           handleResult = result.handleResult
         })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,10 +190,10 @@ export function useXhr(
     isLoading: startNewRequest || state.unresolvedRequirementId !== undefined,
   }
   if (fixedRequirementId !== undefined) {
-    if (state.resolvedRequirementId !== undefined && state.response) {
-      result.xhr = state.response.xhr
-    } else if (foundResultCache !== undefined) {
+    if (foundResultCache !== undefined) {
       result.xhr = foundResultCache.result.xhr
+    } else if (state.resolvedRequirementId !== undefined && state.response) {
+      result.xhr = state.response.xhr
     }
   }
   return result

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,10 +99,10 @@ export function useXhr(
 ): UseXhrResult {
   const [state, setState] = React.useState<UseXhrState>(defaultUseXhrState)
   const unmountedRef = React.useRef(false)
-  const fixedRequirementId: UseXhrRequirementId | undefined =
-    requirementId !== undefined ? requirementId : requestData
   const maxResultCache = options.maxResultCache !== undefined
     ? options.maxResultCache : 100
+  const fixedRequirementId: UseXhrRequirementId | undefined =
+    requirementId !== undefined ? requirementId : requestData
   const invalidRequestData =
     requestData === undefined && requirementId !== undefined
   const requestDataChangedIllegally =
@@ -118,7 +118,9 @@ export function useXhr(
     !areEquivalentAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
     foundResultCache === undefined
 
-  if (invalidRequestData) {
+  if (maxResultCache < 1) {
+    throw new Error('`maxResultCache` is less than 1.')
+  } else if (invalidRequestData) {
     throw new Error('Can not specify only `requirementId`.')
   } else if (requestDataChangedIllegally) {
     throw new Error('Can not change the `requestData` associated with the `requirementId`.')

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,10 @@ export function recordResultCache(
   return newResultCaches.slice(extraNumber, extraNumber + maxNumber)
 }
 
+type UseXhrOptions = {
+  maxResultCache?: number,
+}
+
 export type UseXhrResult = {
   isLoading: boolean,
   xhr?: XMLHttpRequest,
@@ -93,11 +97,14 @@ const defaultUseXhrState: UseXhrState = {
 export function useXhr(
   requestData: SendHttpRequestData | undefined,
   requirementId: UseXhrRequirementId | undefined = undefined,
+  options: UseXhrOptions = {},
 ): UseXhrResult {
   const [state, setState] = React.useState<UseXhrState>(defaultUseXhrState)
   const unmountedRef = React.useRef(false)
   const fixedRequirementId: UseXhrRequirementId | undefined =
     requirementId !== undefined ? requirementId : requestData
+  const maxResultCache = options.maxResultCache !== undefined
+    ? options.maxResultCache : 100
   const invalidRequestData =
     requestData === undefined && requirementId !== undefined
   const requestDataChangedIllegally =
@@ -168,8 +175,7 @@ export function useXhr(
                       xhr: response.xhr,
                     },
                   },
-                  // TODO: Parameterize
-                  100,
+                  maxResultCache,
                 )
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import isEqual = require('lodash.isequal')
 
-function areEqualAAndB(a: any, b: any): boolean {
+function areEquivalentAAndB(a: any, b: any): boolean {
   return isEqual(a, b)
 }
 
@@ -51,7 +51,7 @@ function findResultCache(
 ): UseXhrResultCache | undefined {
   for (let i = 0; i < resultCaches.length; i++) {
     const resultCache = resultCaches[i]
-    if (areEqualAAndB(resultCache.requirementId, requirementId)) {
+    if (areEquivalentAAndB(resultCache.requirementId, requirementId)) {
       return resultCache
     }
   }
@@ -109,16 +109,16 @@ export function useXhr(
     requestData === undefined && requirementId !== undefined
   const requestDataChangedIllegally =
     fixedRequirementId !== undefined &&
-    areEqualAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
-    !areEqualAAndB(requestData, state.unresolvedRequestData)
+    areEquivalentAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
+    !areEquivalentAAndB(requestData, state.unresolvedRequestData)
   const foundResultCache = fixedRequirementId !== undefined
     ? findResultCache(state.resultCaches, fixedRequirementId)
     : undefined
   const startNewRequest =
     requestData !== undefined &&
     fixedRequirementId !== undefined &&
-    !areEqualAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
-    !areEqualAAndB(fixedRequirementId, state.resolvedRequirementId) &&
+    !areEquivalentAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
+    !areEquivalentAAndB(fixedRequirementId, state.resolvedRequirementId) &&
     foundResultCache === undefined
 
   if (invalidRequestData) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,6 @@ export type UseXhrResult = {
 
 type UseXhrState = {
   reservedNewRequest: boolean,
-  resolvedRequirementId?: UseXhrRequirementId | undefined,
-  response?: SendHttpRequestResult,
   // The old element is saved at the top. So-called last-in first-out.
   resultCaches: UseXhrResultCache[],
   unresolvedRequestData?: SendHttpRequestData,
@@ -118,7 +116,6 @@ export function useXhr(
     requestData !== undefined &&
     fixedRequirementId !== undefined &&
     !areEquivalentAAndB(fixedRequirementId, state.unresolvedRequirementId) &&
-    !areEquivalentAAndB(fixedRequirementId, state.resolvedRequirementId) &&
     foundResultCache === undefined
 
   if (invalidRequestData) {
@@ -165,8 +162,6 @@ export function useXhr(
               // TODO: Receive the error object too.
               return {
                 reservedNewRequest: false,
-                resolvedRequirementId: unresolvedRequirementId,
-                response,
                 resultCaches: recordResultCache(
                   state.resultCaches,
                   {
@@ -189,12 +184,8 @@ export function useXhr(
   const result: UseXhrResult = {
     isLoading: startNewRequest || state.unresolvedRequirementId !== undefined,
   }
-  if (fixedRequirementId !== undefined) {
-    if (foundResultCache !== undefined) {
-      result.xhr = foundResultCache.result.xhr
-    } else if (state.resolvedRequirementId !== undefined && state.response) {
-      result.xhr = state.response.xhr
-    }
+  if (fixedRequirementId !== undefined && foundResultCache !== undefined) {
+    result.xhr = foundResultCache.result.xhr
   }
   return result
 }


### PR DESCRIPTION
## TODO
- [x] 結果キャッシュの上限を設定可能にする。
- [x] 結果キャッシュ上限を 1 にしたときのテストを書く。
- [x] foundResultCache が存在するとき、requirementId と resolvedRequirementId が一致していない。 
  - [x] そもそも、resolvedRequirementId を削除できないか検討する。
- [x] maxResultCache に不正な値を設定したらエラーにする。