### PR TITLE
Return XHR errors

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -116,7 +116,7 @@ describe('src/index', () => {
           }, 1)
         })
 
-        it('should return at least one abort event', (done) => {
+        it('should return at least one "abort" event', (done) => {
           const xhr = sendHttpRequest(requestData, (error_, result) => {
             expect(result.events.length).toBeGreaterThan(0)
             expect(result.events.some((event) => event.type === 'abort')).toBe(true)
@@ -125,6 +125,36 @@ describe('src/index', () => {
           setTimeout(() => {
             xhr.abort()
           }, 1)
+        })
+      })
+
+      describe('when it received "timeout" event', () => {
+        const requestData: SendHttpRequestData = {
+          httpMethod: 'GET',
+          url: '/foo',
+        }
+        const options = {
+          timeout: 1,
+        }
+
+        beforeEach(() => {
+          xhrMock.get('/foo', () => new Promise(() => {}))
+        })
+
+        it('should return an error', (done) => {
+          sendHttpRequest(requestData, (error, result_) => {
+            expect(error).toBeInstanceOf(Error)
+            expect(error?.message).toContain(' XHR error ')
+            done()
+          }, options)
+        })
+
+        it('should return at least one "timeout" event', (done) => {
+          sendHttpRequest(requestData, (error_, result) => {
+            expect(result.events.length).toBeGreaterThan(0)
+            expect(result.events.some((event) => event.type === 'timeout')).toBe(true)
+            done()
+          }, options)
         })
       })
     })

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -256,6 +256,11 @@ describe('src/index', () => {
       })
     })
 
+    describe('options.timeout', () => {
+      // Omit it, because it is not easy to write and probably can be verified by other tests.
+      it.todo('should be passed to sendHttpRequest')
+    })
+
     describe('when it passes the same value with different references to requirementId', () => {
       const requestDataAndRequirementId1: SendHttpRequestData = {
         httpMethod: 'GET',

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,12 @@ export type SendHttpRequestResult = {
 
 export function sendHttpRequest(
   data: SendHttpRequestData,
-  callback: (error: Error | null, result: SendHttpRequestResult) => void,
+  afterLoadend: (error: Error | null, result: SendHttpRequestResult) => void,
 ): void {
   const xhr = new XMLHttpRequest()
-  xhr.onload = function() {
+  xhr.onloadend = function() {
     // TODO: Error handling.
-    callback(null, {xhr})
+    afterLoadend(null, {xhr})
   }
   xhr.open(data.httpMethod, data.url)
   const headers = data.headers || {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ export type SendHttpRequestData = {
   url: string,
 }
 
+export type SendHttpRequestOptions = {
+  timeout?: number,
+}
+
 export type SendHttpRequestResult = {
   events: ProgressEvent[],
   xhr: XMLHttpRequest,
@@ -23,7 +27,9 @@ export type SendHttpRequestResult = {
 export function sendHttpRequest(
   data: SendHttpRequestData,
   handleFinishLoadend: (error: Error | null, result: SendHttpRequestResult) => void,
+  options: SendHttpRequestOptions = {},
 ): XMLHttpRequest {
+  const timeout: number | undefined = options.timeout !== undefined ? options.timeout : undefined
   const xhr = new XMLHttpRequest()
   const result: SendHttpRequestResult = {
     xhr,
@@ -62,6 +68,9 @@ export function sendHttpRequest(
   Object.keys(headers).sort().forEach(function(key) {
     xhr.setRequestHeader(key, headers[key])
   })
+  if (timeout !== undefined) {
+    xhr.timeout = timeout
+  }
   xhr.send(data.body !== undefined ? data.body : null)
   return xhr
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,17 +16,46 @@ export type SendHttpRequestData = {
 }
 
 export type SendHttpRequestResult = {
+  events: ProgressEvent[],
   xhr: XMLHttpRequest,
 }
 
 export function sendHttpRequest(
   data: SendHttpRequestData,
-  afterLoadend: (error: Error | null, result: SendHttpRequestResult) => void,
-): void {
+  handleFinishLoadend: (error: Error | null, result: SendHttpRequestResult) => void,
+): XMLHttpRequest {
   const xhr = new XMLHttpRequest()
-  xhr.onloadend = function() {
-    // TODO: Error handling.
-    afterLoadend(null, {xhr})
+  const result: SendHttpRequestResult = {
+    xhr,
+    events: [],
+  }
+  xhr.onloadend = function(event: ProgressEvent) {
+    result.events.push(event)
+    const error: Error | null =
+      result.events.some(function(event) {
+        return ['abort', 'error', 'timeout'].indexOf(event.type) !== -1
+      })
+      ? new Error('Some XHR error has occurred.')
+      : null
+    handleFinishLoadend(error, result)
+  }
+  xhr.onloadstart = function(event: ProgressEvent) {
+    result.events.push(event)
+  }
+  xhr.onabort = function(event: ProgressEvent) {
+    result.events.push(event)
+  }
+  xhr.onerror = function(event: ProgressEvent) {
+    result.events.push(event)
+  }
+  xhr.onprogress = function(event: ProgressEvent) {
+    result.events.push(event)
+  }
+  xhr.onload = function(event: ProgressEvent) {
+    result.events.push(event)
+  }
+  xhr.ontimeout = function(event: ProgressEvent) {
+    result.events.push(event)
   }
   xhr.open(data.httpMethod, data.url)
   const headers = data.headers || {}
@@ -34,6 +63,7 @@ export function sendHttpRequest(
     xhr.setRequestHeader(key, headers[key])
   })
   xhr.send(data.body !== undefined ? data.body : null)
+  return xhr
 }
 
 export type UseXhrRequirementId = number | string | SendHttpRequestData


### PR DESCRIPTION
- [x] xhr のエラーを返せるようにする。
  - [x] sendHttpRequest がエラー的なものを含む全てのイベントの結果を返せるようにする。
    - [x] onload ではなく onloadend で xhr を返すようにする。
    - [x] error などの各種イベントが発火していたら、onloadend のコールバック経由で返す。
    - [x] timeout の設定ができるようにする。
  - [x] useXhr の結果として返す。