### PR TITLE
Adjust CircleCI settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,25 @@ executors:
   my-node-v12:
     docker:
       - image: circleci/node:12.18.2
+  my-node-v10:
+    docker:
+      - image: circleci/node:10.19.0
 orbs:
   node: circleci/node@3.0.1
 jobs:
-  build-and-test:
+  build-and-test-on-node-v12:
     executor:
       name: my-node-v12
+    steps:
+      - checkout
+      - run: node --version
+      - run: npm --version
+      - node/install-packages
+      - run: npm run type-check
+      - run: npm test
+  build-and-test-on-node-v10:
+    executor:
+      name: my-node-v10
     steps:
       - checkout
       - run: node --version
@@ -19,4 +32,5 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - build-and-test
+      - build-and-test-on-node-v12
+      - build-and-test-on-node-v10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,6 @@ jobs:
       - run: npm run type-check
       - run: npm test
 workflows:
-    build-and-test:
-      jobs:
-        - build-and-test
+  build-and-test:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,16 @@
 version: 2.1
+executors:
+  my-node-v12:
+    docker:
+      - image: circleci/node:12.18.2
 orbs:
   node: circleci/node@3.0.1
 jobs:
   build-and-test:
     executor:
-      name: node/default
+      name: my-node-v12
     steps:
       - checkout
-      - node/install:
-          node-version: 12.18.2
       - run: node --version
       - run: npm --version
       - node/install-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
       - checkout
       - run: node --version
       - run: npm --version
-      - node/install-packages
+      - node/install-packages:
+        cache-version: node12-v1
       - run: npm run type-check
       - run: npm test
   build-and-test-on-node-v10:
@@ -26,7 +27,8 @@ jobs:
       - checkout
       - run: node --version
       - run: npm --version
-      - node/install-packages
+      - node/install-packages:
+        cache-version: node10-v1
       - run: npm run type-check
       - run: npm test
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,9 @@ jobs:
       - checkout
       - run: node --version
       - run: npm --version
-      - node/install-packages:
-        cache-version: node12-v1
+      -
+        node/install-packages:
+          cache-version: node12-v1
       - run: npm run type-check
       - run: npm test
   build-and-test-on-node-v10:
@@ -27,8 +28,9 @@ jobs:
       - checkout
       - run: node --version
       - run: npm --version
-      - node/install-packages:
-        cache-version: node10-v1
+      -
+        node/install-packages:
+          cache-version: node10-v1
       - run: npm run type-check
       - run: npm test
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           node-version: 12.18.2
       - run: node --version
       - run: npm --version
-      - run: npm install
+      - node/install-packages
       - run: npm run type-check
       - run: npm test
 workflows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -873,9 +873,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.41",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
-      "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
+      "version": "16.9.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
+      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "^26.0.3",
     "@types/jsdom": "^16.2.3",
     "@types/lodash.isequal": "^4.5.5",
-    "@types/react": "^16.9.41",
+    "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
     "@types/react-test-renderer": "^16.9.2",
     "@types/sinon": "^9.0.4",


### PR DESCRIPTION
- [x] 全体的に config.yml を見直す。
- [x] CircleCI で node や npm のインストール結果がキャッシュされてないかもしれない。
  - [x] npm packages は orb の方のコマンドでインストールする。
  - [x] node は circleci が用意している docker image を使うといいとのこと。
    - [circleci/node](https://circleci.com/orbs/registry/orb/circleci/node) のドキュメントに "Recommendation: It is highly recommended to utilize an environment such as Docker with Node preinstalled." と各所に書いてある。
- [x] node v10 でも CI を実行する。
  - [x] node v12 と v10 の job を分けて、2 jobs 実行する。
  - [x] npm packages のキャッシュが v12 と v10 の job 間で共有されないようにする。
  - [x] 片方の job が落ちたら workflow 全体が落ちることを確認する。

node-v12 の方を落とした図） [落ちたjobの結果](https://circleci.com/gh/kjirou/react-use-xhr/68)
![image](https://user-images.githubusercontent.com/648041/87243078-d8713a80-c46d-11ea-9eaa-31fa4f16db39.png)

node-v10 の方を落とした図）[落ちたjobの結果](https://circleci.com/gh/kjirou/react-use-xhr/70)
![image](https://user-images.githubusercontent.com/648041/87243104-1cfcd600-c46e-11ea-976a-6fe9847999df.png)
