### PR TITLE
Always return "events" property

### DIFF
--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -152,7 +152,7 @@ describe('src/index', () => {
       })
     })
 
-    describe('can not change query if queryId is not changed', () => {
+    describe('when it changes only query without changing queryId', () => {
       const originalConsoleError = console.error;
 
       beforeEach(() => {
@@ -165,7 +165,7 @@ describe('src/index', () => {
         console.error = originalConsoleError
       })
 
-      it('should throw an error if query is changed in the same queryId', async () => {
+      it('should throw an error', async () => {
         const Tester: React.FC<{body: string}> = (props) => {
           useXhr({
             httpMethod: 'GET',
@@ -212,7 +212,7 @@ describe('src/index', () => {
       beforeEach(async () => {
         xhrMock.use('GET', '/foo', {
           status: 200,
-          body: 'BAR',
+          body: 'FOO',
         })
         handleResult = sinon.spy()
         await ReactTestRenderer.act(async () => {
@@ -222,14 +222,44 @@ describe('src/index', () => {
         })
       })
 
-      it('should return isLoading=false without any xhr instance at the first render', () => {
-        expect(handleResult.firstCall.args[0].isLoading).toBe(false)
-        expect(handleResult.firstCall.args[0].xhr).toBe(undefined)
+      describe('in the first render', () => {
+        let result: UseXhrResult
+
+        beforeEach(() => {
+          result = handleResult.firstCall.args[0]
+        });
+
+        it('should return isLoading=false', () => {
+          expect(result.isLoading).toBe(false)
+        })
+
+        it('should return an empty events', () => {
+          expect(result.events).toEqual([])
+        })
+
+        it('should not return the "xhr" property', () => {
+          expect(result).not.toHaveProperty('xhr')
+        })
       })
 
-      it('should return isLoading=false without any xhr instance at the last render', () => {
-        expect(handleResult.lastCall.args[0].isLoading).toBe(false)
-        expect(handleResult.lastCall.args[0].xhr).toBe(undefined)
+      describe('in the last render', () => {
+        let result: UseXhrResult
+
+        beforeEach(() => {
+          result = handleResult.lastCall.args[0]
+        });
+
+        it('should return isLoading=false', () => {
+          expect(result.isLoading).toBe(false)
+        })
+
+        it('should return an empty events', () => {
+          expect(result.events).toEqual([])
+        })
+
+        it('should not return the "xhr" property', () => {
+          expect(result).not.toHaveProperty('xhr')
+        })
       })
     })
 
@@ -250,7 +280,7 @@ describe('src/index', () => {
       beforeEach(async () => {
         xhrMock.use('GET', '/foo', {
           status: 200,
-          body: 'BAR',
+          body: 'FOO',
         })
         handleResult = sinon.spy()
         await ReactTestRenderer.act(async () => {
@@ -260,42 +290,60 @@ describe('src/index', () => {
         })
       })
 
-      it('should return isLoading=true without any property at the first render', () => {
-        expect(handleResult.firstCall.args[0].isLoading).toBe(true)
-        expect(handleResult.firstCall.args[0]).not.toHaveProperty('xhr')
-        expect(handleResult.firstCall.args[0]).not.toHaveProperty('events')
-        expect(handleResult.firstCall.args[0]).not.toHaveProperty('error')
+      describe('in the first render', () => {
+        let result: UseXhrResult
+
+        beforeEach(() => {
+          result = handleResult.firstCall.args[0]
+        });
+
+        it('should return isLoading=true', () => {
+          expect(result.isLoading).toBe(true)
+        })
+
+        it('should return an empty events', () => {
+          expect(result.events).toEqual([])
+        })
+
+        it('should not return the "xhr" property', () => {
+          expect(result).not.toHaveProperty('xhr')
+        })
       })
 
-      it('should return isLoading=false at the last render', () => {
-        expect(handleResult.lastCall.args[0].isLoading).toBe(false)
-      })
+      describe('in the last render', () => {
+        let result: UseXhrResult
 
-      it('should return a xhr instance at the last render', () => {
-        expect(handleResult.lastCall.args[0].xhr).toBeInstanceOf(XMLHttpRequest)
-        expect(handleResult.lastCall.args[0].xhr.status).toBe(200)
-        expect(handleResult.lastCall.args[0].xhr.responseText).toBe('BAR')
-      })
+        beforeEach(() => {
+          result = handleResult.lastCall.args[0]
+        });
 
-      it('should include "loadend" event to the end of the events at the last render', () => {
-        const events = handleResult.lastCall.args[0].events
-        const lastEvent = events[events.length - 1]
-        expect(lastEvent.type).toBe('loadend')
-      })
+        it('should return isLoading=false', () => {
+          expect(result.isLoading).toBe(false)
+        })
 
-      it('should return without any error at the last render', () => {
-        expect(handleResult.lastCall.args[0]).not.toHaveProperty('error')
+        it('should include the "loadstart" in the events at the first', () => {
+          expect(result.events[0].type).toBe('loadstart')
+        })
+
+        it('should include the "loadend" in the events at the last', () => {
+          expect(result.events[result.events.length - 1].type).toBe('loadend')
+        })
+
+        it('should return an xhr instance', () => {
+          expect(result.xhr).toBeInstanceOf(XMLHttpRequest)
+          expect(result.xhr?.status).toBe(200)
+          expect(result.xhr?.responseText).toBe('FOO')
+        })
       })
     })
 
-    describe('when it sets an undefined after setting a value to queryId', () => {
+    describe('when it sets an undefined to query after setting a value', () => {
       type TesterProps = {
         handleResult: any,
         query: SendHttpRequestData | undefined,
-        queryId: string | undefined,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr(props.query, props.queryId)
+        const result = useXhr(props.query)
         props.handleResult(result)
         return React.createElement('div')
       }
@@ -305,13 +353,12 @@ describe('src/index', () => {
       beforeEach(async () => {
         xhrMock.use('GET', '/foo', {
           status: 200,
-          body: 'BAR',
+          body: 'FOO',
         })
         handleResult = sinon.spy()
         await ReactTestRenderer.act(async () => {
           testRenderer = ReactTestRenderer.create(
             React.createElement(Tester, {
-              queryId: 'a',
               query: {
                 httpMethod: 'GET',
                 url: '/foo',
@@ -323,7 +370,6 @@ describe('src/index', () => {
         await ReactTestRenderer.act(async () => {
           testRenderer.update(
             React.createElement(Tester, {
-              queryId: undefined,
               query: undefined,
               handleResult,
             }),
@@ -331,43 +377,41 @@ describe('src/index', () => {
         })
       })
 
-      it('should return isLoading=false and xhr=undefined at the last render', () => {
+      it('should return isLoading=false without any xhr instance at the last render', () => {
         expect(handleResult.lastCall.args[0].isLoading).toBe(false)
-        expect(handleResult.lastCall.args[0].xhr).toBe(undefined)
+        expect(handleResult.lastCall.args[0]).not.toHaveProperty('xhr')
       })
     })
 
-    describe('when it sends and receives the 2nd request(="b") before resolving the 1st request(="a")', () => {
+    describe('when it sends and receives the second request before resolving the first request', () => {
       type TesterProps = {
         handleResult: any,
         query: SendHttpRequestData,
-        queryId: string,
       }
       const Tester: React.FC<TesterProps> = (props) => {
-        const result = useXhr(props.query, props.queryId)
-        props.handleResult(props.queryId, result)
+        const result = useXhr(props.query)
+        props.handleResult(result)
         return React.createElement('div')
       }
       let handleResult: TesterProps['handleResult']
       let testRenderer: any = undefined
 
       beforeEach(async () => {
-        xhrMock.use('GET', '/foo', delay({
+        xhrMock.use('GET', '/first', delay({
           status: 200,
-          body: 'FOO',
+          body: 'FIRST',
         }, 100))
-        xhrMock.use('GET', '/bar', delay({
+        xhrMock.use('GET', '/second', delay({
           status: 200,
-          body: 'BAR',
+          body: 'SECOND',
         }, 50))
         handleResult = sinon.spy()
         await ReactTestRenderer.act(async () => {
           testRenderer = ReactTestRenderer.create(
             React.createElement(Tester, {
-              queryId: 'a',
               query: {
                 httpMethod: 'GET',
-                url: '/foo',
+                url: '/first',
               },
               handleResult,
             }),
@@ -376,10 +420,9 @@ describe('src/index', () => {
         await ReactTestRenderer.act(async () => {
           testRenderer.update(
             React.createElement(Tester, {
-              queryId: 'b',
               query: {
                 httpMethod: 'GET',
-                url: '/bar',
+                url: '/second',
               },
               handleResult,
             }),
@@ -388,30 +431,25 @@ describe('src/index', () => {
         })
       })
 
-      it('should return the result of "b" at the last render', () => {
-        expect(handleResult.lastCall.args[0]).toBe('b')
-        expect(handleResult.lastCall.args[1].xhr).toBeInstanceOf(XMLHttpRequest)
-        expect(handleResult.lastCall.args[1].xhr.responseText).toBe('BAR')
+      it('should return a result of the second request at the last render', () => {
+        expect(handleResult.lastCall.args[0].xhr).toBeInstanceOf(XMLHttpRequest)
+        expect(handleResult.lastCall.args[0].xhr.responseText).toBe('SECOND')
       })
 
-      it('should never receives the result of "a"', () => {
-        const aCalls = handleResult.getCalls()
-          .filter((call: any) => call.args[0] === 'a')
-        expect(aCalls.length).toBeGreaterThan(0)
-        for (const call of aCalls) {
-          expect(call.args[1].isLoading).toBe(true)
-          expect(call.args[1].xhr).toBe(undefined)
+      it('should never receives any result of the first request', () => {
+        for (const call of handleResult.getCalls()) {
+          expect(call.args[0].xhr?.responseText).not.toBe('FIRST')
         }
       })
 
-      it('should switch isLoading value from true to false only once', () => {
+      it('should switch "isLoading" value from true to false only once', () => {
         let nextExpectedValue = true
         for (const call of handleResult.getCalls()) {
-          const isLoading = call.args[1].isLoading
+          const isLoading = call.args[0].isLoading
           if (nextExpectedValue === true && isLoading === false) {
             nextExpectedValue = false
           }
-          expect(call.args[1].isLoading).toBe(nextExpectedValue)
+          expect(call.args[0].isLoading).toBe(nextExpectedValue)
         }
       })
     })
@@ -661,10 +699,6 @@ describe('src/index', () => {
 
       it('should include "timeout" event in the result at the last render', () => {
         expect(handleResult.lastCall.args[0].events.some((e: any) => e.type === 'timeout')).toBe(true)
-      })
-
-      it('should have an error in the result at the last render', () => {
-        expect(handleResult.lastCall.args[0].error).toBeInstanceOf(Error)
       })
     })
 

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -64,99 +64,148 @@ describe('src/utils', () => {
         {httpMethod: 'DELETE'},
       ]
       testCases.forEach(({httpMethod}) => {
-        describe(`when it succeeded ${httpMethod} request`, () => {
+        describe(`when the ${httpMethod} resource exists`, () => {
           const requestData = {
             httpMethod,
             url: '/foo',
           }
+          let handleEvent: any
 
           beforeEach(() => {
             xhrMock.use(httpMethod, '/foo', {
               status: 200,
-              body: 'BAR',
+              body: 'FOO',
             })
+            handleEvent = sinon.spy()
           })
 
-          it('can receive xhr instance', (done) => {
-            sendHttpRequest(requestData, (error_, result) => {
-              expect(result.xhr).toBeInstanceOf(XMLHttpRequest)
-              expect(result.xhr?.status).toBe(200)
-              expect(result.xhr?.responseText).toBe('BAR')
-              done()
-            })
+          it('should return "loadstart" event at the first call', (done) => {
+            sendHttpRequest(requestData, handleEvent)
+            setTimeout(() => {
+              const result = handleEvent.lastCall.args[1]
+              try {
+                expect(result.events[0].type).toBe('loadstart')
+                done()
+              } catch (error) {
+                done(error)
+              }
+            }, 25)
           })
 
-          it('should not return any error', (done) => {
-            sendHttpRequest(requestData, (error, result_) => {
-              expect(error).toBe(null)
-              done()
-            })
+          it('should return "loadend" event with an xhr instance without an error at the last call', (done) => {
+            sendHttpRequest(requestData, handleEvent)
+            setTimeout(() => {
+              const [error, result] = handleEvent.lastCall.args
+              try {
+                expect(result.events[result.events.length - 1].type).toBe('loadend')
+                expect(result.xhr).toBeInstanceOf(XMLHttpRequest)
+                expect(error).toBe(null)
+                done()
+              } catch (error) {
+                done(error)
+              }
+            }, 25)
           })
         })
       })
     })
 
-    describe('event handling', () => {
-      describe('when it received "abort" event', () => {
-        const requestData: SendHttpRequestData = {
-          httpMethod: 'GET',
-          url: '/foo',
-        }
+    describe('event handling for each', () => {
+      describe('when it received any "abort" event', () => {
+        let sendHttpRequestForTest: any;
 
         beforeEach(() => {
           xhrMock.get('/foo', () => new Promise(() => {}))
+          sendHttpRequestForTest = (): any => {
+            const handleEvent: any = sinon.spy()
+            const xhr = sendHttpRequest(
+              {
+                httpMethod: 'GET',
+                url: '/foo',
+              },
+              handleEvent,
+            )
+            setTimeout(() => {
+              xhr.abort()
+            }, 1)
+            return handleEvent;
+          }
         })
 
-        it('should return an error', (done) => {
-          const xhr = sendHttpRequest(requestData, (error, result_) => {
-            expect(error).toBeInstanceOf(Error)
-            expect(error?.message).toContain(' XHR error ')
-            done()
-          })
+        it('should return an error at the last call', (done) => {
+          const handleEvent = sendHttpRequestForTest()
           setTimeout(() => {
-            xhr.abort()
-          }, 1)
+            const [error, result] = handleEvent.lastCall.args
+            try {
+              expect(error).toBeInstanceOf(Error)
+              expect(error.message).toContain(' XHR error ')
+              done()
+            } catch (exception) {
+              done(exception)
+            }
+          }, 25)
         })
 
-        it('should return at least one "abort" event', (done) => {
-          const xhr = sendHttpRequest(requestData, (error_, result) => {
-            expect(result.events.length).toBeGreaterThan(0)
-            expect(result.events.some((event) => event.type === 'abort')).toBe(true)
-            done()
-          })
+        it('should include an "abort" event before the "loadend" event at the last call', (done) => {
+          const handleEvent = sendHttpRequestForTest()
           setTimeout(() => {
-            xhr.abort()
-          }, 1)
+            const result = handleEvent.lastCall.args[1]
+            try {
+              expect(result.events[result.events.length - 2].type).toBe('abort')
+              expect(result.events[result.events.length - 1].type).toBe('loadend')
+              done()
+            } catch (exception) {
+              done(exception)
+            }
+          }, 25)
         })
       })
 
-      describe('when it received "timeout" event', () => {
-        const requestData: SendHttpRequestData = {
-          httpMethod: 'GET',
-          url: '/foo',
-        }
-        const options = {
-          timeout: 1,
-        }
+      describe('when it received any "timeout" event', () => {
+        let sendHttpRequestForTest: any;
 
         beforeEach(() => {
           xhrMock.get('/foo', () => new Promise(() => {}))
+          sendHttpRequestForTest = (): any => {
+            const handleEvent: any = sinon.spy()
+            sendHttpRequest(
+              {
+                httpMethod: 'GET',
+                url: '/foo',
+              },
+              handleEvent,
+              {timeout: 1},
+            )
+            return handleEvent;
+          }
         })
 
-        it('should return an error', (done) => {
-          sendHttpRequest(requestData, (error, result_) => {
-            expect(error).toBeInstanceOf(Error)
-            expect(error?.message).toContain(' XHR error ')
-            done()
-          }, options)
+        it('should return an error at the last call', (done) => {
+          const handleEvent = sendHttpRequestForTest()
+          setTimeout(() => {
+            const [error, result] = handleEvent.lastCall.args
+            try {
+              expect(error).toBeInstanceOf(Error)
+              expect(error.message).toContain(' XHR error ')
+              done()
+            } catch (exception) {
+              done(exception)
+            }
+          }, 25)
         })
 
-        it('should return at least one "timeout" event', (done) => {
-          sendHttpRequest(requestData, (error_, result) => {
-            expect(result.events.length).toBeGreaterThan(0)
-            expect(result.events.some((event) => event.type === 'timeout')).toBe(true)
-            done()
-          }, options)
+        it('should include a "timeout" event before the "loadend" event at the last call', (done) => {
+          const handleEvent = sendHttpRequestForTest()
+          setTimeout(() => {
+            const result = handleEvent.lastCall.args[1]
+            try {
+              expect(result.events[result.events.length - 2].type).toBe('timeout')
+              expect(result.events[result.events.length - 1].type).toBe('loadend')
+              done()
+            } catch (exception) {
+              done(exception)
+            }
+          }, 25)
         })
       })
     })

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -86,23 +86,22 @@ describe('src/utils', () => {
               try {
                 expect(result.events[0].type).toBe('loadstart')
                 done()
-              } catch (error) {
-                done(error)
+              } catch (exception) {
+                done(exception)
               }
             }, 25)
           })
 
-          it('should return "loadend" event with an xhr instance without an error at the last call', (done) => {
+          it('should return "loadend" event with an xhr instance at the last call', (done) => {
             sendHttpRequest(requestData, handleEvent)
             setTimeout(() => {
               const [error, result] = handleEvent.lastCall.args
               try {
                 expect(result.events[result.events.length - 1].type).toBe('loadend')
                 expect(result.xhr).toBeInstanceOf(XMLHttpRequest)
-                expect(error).toBe(null)
                 done()
-              } catch (error) {
-                done(error)
+              } catch (exception) {
+                done(exception)
               }
             }, 25)
           })
@@ -130,20 +129,6 @@ describe('src/utils', () => {
             }, 1)
             return handleEvent;
           }
-        })
-
-        it('should return an error at the last call', (done) => {
-          const handleEvent = sendHttpRequestForTest()
-          setTimeout(() => {
-            const [error, result] = handleEvent.lastCall.args
-            try {
-              expect(error).toBeInstanceOf(Error)
-              expect(error.message).toContain(' XHR error ')
-              done()
-            } catch (exception) {
-              done(exception)
-            }
-          }, 25)
         })
 
         it('should include an "abort" event before the "loadend" event at the last call', (done) => {
@@ -178,20 +163,6 @@ describe('src/utils', () => {
             )
             return handleEvent;
           }
-        })
-
-        it('should return an error at the last call', (done) => {
-          const handleEvent = sendHttpRequestForTest()
-          setTimeout(() => {
-            const [error, result] = handleEvent.lastCall.args
-            try {
-              expect(error).toBeInstanceOf(Error)
-              expect(error.message).toContain(' XHR error ')
-              done()
-            } catch (exception) {
-              done(exception)
-            }
-          }, 25)
         })
 
         it('should include a "timeout" event before the "loadend" event at the last call', (done) => {

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -80,8 +80,8 @@ describe('src/utils', () => {
           it('can receive xhr instance', (done) => {
             sendHttpRequest(requestData, (error_, result) => {
               expect(result.xhr).toBeInstanceOf(XMLHttpRequest)
-              expect(result.xhr.status).toBe(200)
-              expect(result.xhr.responseText).toBe('BAR')
+              expect(result.xhr?.status).toBe(200)
+              expect(result.xhr?.responseText).toBe('BAR')
               done()
             })
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ type UseXhrResultCache = {
   result: {
     error?: Error,
     events: SendHttpRequestResult['events'],
-    xhr: SendHttpRequestResult['xhr'],
+    xhr?: SendHttpRequestResult['xhr'],
   },
 }
 
@@ -135,8 +135,8 @@ export function useXhr(
                 const resultCache: UseXhrResultCache = {
                   queryId: unresolvedQueryId,
                   result: {
-                    xhr: requestResult.xhr,
                     events: requestResult.events,
+                    ...(requestResult.xhr ? {xhr: requestResult.xhr} : {}),
                   },
                 }
                 if (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export function useXhr(
           if (!unmountedRef.current) {
             // State Transition: 3
             setState(function(current) {
-              const unresolvedQueryId = current.unresolvedQueryId;
+              const unresolvedQueryId = current.unresolvedQueryId
               if (
                 unresolvedQueryId !== undefined &&
                 state.unresolvedQueryId === unresolvedQueryId
@@ -145,7 +145,7 @@ export function useXhr(
                 return {
                   reservedNewRequest: false,
                   resultCaches: appendItemAsLastInFirstOut<UseXhrResultCache>(
-                    state.resultCaches, resultCache, maxResultCache)
+                    state.resultCaches, resultCache, maxResultCache),
                 }
               }
               return current

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,16 @@ function findResultCache(resultCaches: UseXhrResultCache[], queryId: QueryId): U
   return undefined
 }
 
+function replaceResultCache(
+  resultCaches: UseXhrResultCache[], replacement: UseXhrResultCache,
+): UseXhrResultCache[] {
+  return resultCaches.map(function(resultCache) {
+    return areEquivalentAAndB(resultCache.queryId, replacement.queryId)
+      ? replacement
+      : resultCache
+  })
+}
+
 export type UseXhrOptionsValue = {
   maxResultCache?: number,
   timeout?: SendHttpRequestOptions['timeout'],
@@ -46,7 +56,7 @@ function deriveSendHttpRequestOptions(useXhrOptions: UseXhrOptionsValue): SendHt
 
 export type UseXhrResult = {
   error?: Error,
-  events?: SendHttpRequestResult['events'],
+  events: SendHttpRequestResult['events'],
   isLoading: boolean,
   xhr?: SendHttpRequestResult['xhr'],
 }
@@ -57,6 +67,39 @@ type UseXhrState = {
   resultCaches: UseXhrResultCache[],
   unresolvedQuery?: Query,
   unresolvedQueryId?: QueryId | undefined,
+}
+
+function receiveResponseIntoState(
+  state: UseXhrState,
+  maxResultCache: NonNullable<UseXhrOptionsValue['maxResultCache']>,
+  error: Error | null,
+  response: SendHttpRequestResult,
+): UseXhrState {
+  const unresolvedQueryId = state.unresolvedQueryId
+  if (unresolvedQueryId === undefined) {
+    throw new Error('unresolvedQueryId` should be present.')
+  }
+  const requestCompleted = response.xhr !== undefined
+  const newResultCache: UseXhrResultCache = {
+    queryId: unresolvedQueryId,
+    result: {
+      events: response.events,
+      ...(error ? {error: error} : {}),
+      ...(requestCompleted ? {xhr: response.xhr} : {}),
+    },
+  }
+  const resultCaches: UseXhrResultCache[] = findResultCache(state.resultCaches, unresolvedQueryId)
+    ? replaceResultCache(state.resultCaches, newResultCache)
+    : appendItemAsLastInFirstOut<UseXhrResultCache>(state.resultCaches, newResultCache, maxResultCache)
+  const newState: UseXhrState = {
+    reservedNewRequest: false,
+    resultCaches,
+  }
+  if (!requestCompleted) {
+    newState.unresolvedQueryId = unresolvedQueryId
+    newState.unresolvedQuery = state.unresolvedQuery
+  }
+  return newState
 }
 
 export function useXhr(
@@ -73,17 +116,17 @@ export function useXhr(
     ? options.maxResultCache : 1
   const sendHttpRequestOptions = deriveSendHttpRequestOptions(options)
   const fixedQueryId: QueryId | undefined = queryId !== undefined ? queryId : query
+  const resultRequired = fixedQueryId !== undefined
   const invalidQuery = query === undefined && queryId !== undefined
   const queryChangedIllegally =
-    fixedQueryId !== undefined &&
+    resultRequired &&
     areEquivalentAAndB(fixedQueryId, state.unresolvedQueryId) &&
     !areEquivalentAAndB(query, state.unresolvedQuery)
   const foundResultCache = fixedQueryId !== undefined
     ? findResultCache(state.resultCaches, fixedQueryId)
     : undefined
   const startNewRequest =
-    query !== undefined &&
-    fixedQueryId !== undefined &&
+    resultRequired &&
     !areEquivalentAAndB(fixedQueryId, state.unresolvedQueryId) &&
     foundResultCache === undefined
 
@@ -123,30 +166,17 @@ export function useXhr(
 
       sendHttpRequest(
         state.unresolvedQuery as Query,
-        function(error, requestResult) {
+        function(error, response) {
           if (!unmountedRef.current) {
             // State Transition: 3
-            setState(function(current) {
-              const unresolvedQueryId = current.unresolvedQueryId
+            setState(function(currentState) {
               if (
-                unresolvedQueryId !== undefined &&
-                state.unresolvedQueryId === unresolvedQueryId
+                currentState.unresolvedQueryId !== undefined &&
+                areEquivalentAAndB(currentState.unresolvedQueryId, state.unresolvedQueryId)
               ) {
-                const resultCache: UseXhrResultCache = {
-                  queryId: unresolvedQueryId,
-                  result: {
-                    events: requestResult.events,
-                    ...(error ? {error: error} : {}),
-                    ...(requestResult.xhr ? {xhr: requestResult.xhr} : {}),
-                  },
-                }
-                return {
-                  reservedNewRequest: false,
-                  resultCaches: appendItemAsLastInFirstOut<UseXhrResultCache>(
-                    state.resultCaches, resultCache, maxResultCache),
-                }
+                return receiveResponseIntoState(currentState, maxResultCache, error, response)
               }
-              return current
+              return currentState
             })
           }
         },
@@ -157,10 +187,13 @@ export function useXhr(
 
   const result: UseXhrResult = {
     isLoading: startNewRequest || state.unresolvedQueryId !== undefined,
+    events: [],
   }
-  if (fixedQueryId !== undefined && foundResultCache !== undefined) {
-    result.xhr = foundResultCache.result.xhr
+  if (resultRequired && foundResultCache) {
     result.events = foundResultCache.result.events
+    if (foundResultCache.result.xhr) {
+      result.xhr = foundResultCache.result.xhr
+    }
     if (foundResultCache.result.error) {
       result.error = foundResultCache.result.error
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,11 +136,9 @@ export function useXhr(
                   queryId: unresolvedQueryId,
                   result: {
                     events: requestResult.events,
+                    ...(error ? {error: error} : {}),
                     ...(requestResult.xhr ? {xhr: requestResult.xhr} : {}),
                   },
-                }
-                if (error) {
-                  resultCache.result.error = error
                 }
                 return {
                   reservedNewRequest: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export type SendHttpRequestOptions = {
 
 export type SendHttpRequestResult = {
   events: ProgressEvent[],
-  xhr: XMLHttpRequest,
+  xhr?: XMLHttpRequest,
 }
 
 export function sendHttpRequest(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ export type SendHttpRequestResult = {
 
 export function sendHttpRequest(
   data: SendHttpRequestData,
-  handleFinishLoadend: (error: Error | null, result: SendHttpRequestResult) => void,
+  handleEvent: (error: Error | null, result: SendHttpRequestResult) => void,
   options: SendHttpRequestOptions = {},
 ): XMLHttpRequest {
   const timeout: number | undefined = options.timeout !== undefined ? options.timeout : undefined
@@ -51,7 +51,7 @@ export function sendHttpRequest(
       })
       ? new Error('Some XHR error has occurred.')
       : null
-    handleFinishLoadend(error, result)
+    handleEvent(error, result)
   }
   xhr.onloadstart = function(event: ProgressEvent) {
     result.events.push(event)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,10 @@ export type SendHttpRequestResult = {
   xhr?: XMLHttpRequest,
 }
 
+/**
+ * The `handleEvent`'s error argument will be passed a runtime error in the event handler,
+ *   but it's now always null.
+ */
 export function sendHttpRequest(
   data: SendHttpRequestData,
   handleEvent: (error: Error | null, result: SendHttpRequestResult) => void,
@@ -46,13 +50,7 @@ export function sendHttpRequest(
       xhr,
       events: allEvents.slice(),
     };
-    const error: Error | null =
-      result.events.some(function(event) {
-        return ['abort', 'error', 'timeout'].indexOf(event.type) !== -1
-      })
-      ? new Error('Some XHR error has occurred.')
-      : null
-    handleEvent(error, result)
+    handleEvent(null, result)
   }
   xhr.onloadstart = function(event: ProgressEvent) {
     allEvents.push(event)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,12 +39,13 @@ export function sendHttpRequest(
 ): XMLHttpRequest {
   const timeout: number | undefined = options.timeout !== undefined ? options.timeout : undefined
   const xhr = new XMLHttpRequest()
-  const result: SendHttpRequestResult = {
-    xhr,
-    events: [],
-  }
+  const allEvents: SendHttpRequestResult['events'] = [];
   xhr.onloadend = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    const result: SendHttpRequestResult = {
+      xhr,
+      events: allEvents.slice(),
+    };
     const error: Error | null =
       result.events.some(function(event) {
         return ['abort', 'error', 'timeout'].indexOf(event.type) !== -1
@@ -54,22 +55,28 @@ export function sendHttpRequest(
     handleEvent(error, result)
   }
   xhr.onloadstart = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.onabort = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.onerror = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.onprogress = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.onload = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.ontimeout = function(event: ProgressEvent) {
-    result.events.push(event)
+    allEvents.push(event)
+    handleEvent(null, {events: allEvents.slice()})
   }
   xhr.open(data.httpMethod, data.url)
   const headers = data.headers || {}


### PR DESCRIPTION
- [x] useXhr は loadend 以外のイベントが返ったときに `{isLoading: true, events}` を返す。
  - [x] `sendHttpRequest` が各イベントの発火毎にコールバックを発火するように変更する。
  - [x] ~~loadstart から始まって progress event が複数回実行されて最後に loadend されるようなテストを書く。~~
    - xhr-mock を介していると信頼性が低いので、ブラウザで手動でやることで保留にする。
- [x] `sendHttpRequest` の `error` は、通信上の障害ではなく、JS のランタイムエラーを返すように変更する。